### PR TITLE
Remove "fruit" from "vfs objects"

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -73,7 +73,7 @@ local master = no
 
 winbind scan trusted domains = yes
 
-vfs objects = fruit streams_xattr
+vfs objects = streams_xattr
 fruit:metadata = stream
 fruit:model = MacSamba
 fruit:posix_rename = yes


### PR DESCRIPTION
fixes #18 
closes #17 

Mitigate CVE-2021-44142