### PR TITLE
Added `hide files` Samba parameter

### DIFF
--- a/.github/config-test.yml
+++ b/.github/config-test.yml
@@ -40,3 +40,4 @@ share:
     validusers: foo
     writelist: foo
     veto: no
+    hidefiles: /_*/

--- a/README.md
+++ b/README.md
@@ -131,6 +131,7 @@ share:
     validusers: foo
     writelist: foo
     veto: no
+    hidefiles: /_*/
 ```
 
 `veto: no` is a list of predefined files and directories that will not be
@@ -140,9 +141,18 @@ visible or accessible:
 /._*/.apdisk/.AppleDouble/.DS_Store/.TemporaryItems/.Trashes/desktop.ini/ehthumbs.db/Network Trash Folder/Temporary Items/Thumbs.db/
 ```
 
-More info: https://www.samba.org/samba/docs/current/man-html/smb.conf.5.html#VETOFILES
+*More info: https://www.samba.org/samba/docs/current/man-html/smb.conf.5.html#VETOFILES*
 
-A more complete example is available [here](examples/compose/data/config.yml).
+`hidefiles: /_*/` is a list of predefined files and directories that will not be visible, but are accessible:
+
+```
+/_*/
+```
+In this example, all files and directories beginning with an underscore (`_`) will be hidden.
+
+*More info: https://www.samba.org/samba/docs/current/man-html/smb.conf.5.html#HIDEFILES*
+
+A more complete `config.yml` example is available [here](examples/compose/data/config.yml).
 
 ### Add users
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -165,6 +165,9 @@ if [[ "$(yq -j e /data/config.yml 2>/dev/null | jq '.share')" != "null" ]]; then
       echo "veto files = /._*/.apdisk/.AppleDouble/.DS_Store/.TemporaryItems/.Trashes/desktop.ini/ehthumbs.db/Network Trash Folder/Temporary Items/Thumbs.db/" >> /etc/samba/smb.conf
       echo "delete veto files = yes" >> /etc/samba/smb.conf
     fi
+    if [[ "$(_jq '.hidefiles')" != "null" ]] && [[ -n "$(_jq '.hidefiles')" ]]; then
+      echo "hide files = $(_jq '.hidefiles')" >> /etc/samba/smb.conf
+    fi
   done
 fi
 

--- a/examples/compose/data/config.yml
+++ b/examples/compose/data/config.yml
@@ -37,6 +37,7 @@ share:
     validusers: foo
     writelist: foo
     veto: no
+    hidefiles: /_*/
   - name: foo-baz
     path: /samba/foo-baz
     browsable: yes


### PR DESCRIPTION
Adds the `hide files=` Samba parameter so that users can hide files and directories while still keeping them accessible.

(Reference: https://www.samba.org/samba/docs/current/man-html/smb.conf.5.html#HIDEFILES)

Changes/additions are as follows:
- Added a `hidefiles` key to `config.yml`
- Updated `entrypoint.sh` to look for this key & echo its value
- Updated the `config.yml` config example
- Added parameter in `config-test.yml` for test workflow
- Updated README with documentation/example