### PR TITLE
Use ports instead of host network mode

### DIFF
--- a/examples/compose/docker-compose.yml
+++ b/examples/compose/docker-compose.yml
@@ -4,7 +4,9 @@ services:
   samba:
     image: crazymax/samba
     container_name: samba
-    network_mode: host
+    ports:
+      - 139:139
+      - 445:445
     volumes:
       - "./data:/data"
       - "./public:/samba/public"


### PR DESCRIPTION
This PR restricts the `docker-compose.yml` to only use Samba ports `139` and `445`.