### PR TITLE
Add CONFIG_FILE env var to set YAML config path

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ Image: crazymax/samba:latest
 * `SAMBA_WIDE_LINKS`: Controls whether or not links in the UNIX file system may be followed by the server. (default `yes`)
 * `SAMBA_HOSTS_ALLOW`: Set of hosts which are permitted to access a service. (default `127.0.0.0/8 10.0.0.0/8 172.16.0.0/12 192.168.0.0/16`)
 * `SAMBA_INTERFACES`: Allows you to override the default network interfaces list.
+* `CONFIG_FILE`: YAML configuration path (default `/data/config.yml`)
 
 > More info: https://www.samba.org/samba/docs/current/man-html/smb.conf.5.html
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
-
 TZ=${TZ:-UTC}
+CONFIG_FILE=${CONFIG_FILE:-/data/config.yml}
 
 SAMBA_WORKGROUP=${SAMBA_WORKGROUP:-WORKGROUP}
 SAMBA_SERVER_STRING=${SAMBA_SERVER_STRING:-Docker Samba Server}
@@ -107,8 +107,8 @@ bind interfaces only = yes
 EOL
 fi
 
-if [[ "$(yq --output-format=json e '(.. | select(tag == "!!str")) |= envsubst' /data/config.yml 2>/dev/null | jq '.auth')" != "null" ]]; then
-  for auth in $(yq -j e '(.. | select(tag == "!!str")) |= envsubst' /data/config.yml 2>/dev/null | jq -r '.auth[] | @base64'); do
+if [[ "$(yq --output-format=json e '(.. | select(tag == "!!str")) |= envsubst' $CONFIG_FILE 2>/dev/null | jq '.auth')" != "null" ]]; then
+  for auth in $(yq -j e '(.. | select(tag == "!!str")) |= envsubst' $CONFIG_FILE 2>/dev/null | jq -r '.auth[] | @base64'); do
     _jq() {
       echo "${auth}" | base64 --decode | jq -r "${1}"
     }
@@ -124,8 +124,8 @@ if [[ "$(yq --output-format=json e '(.. | select(tag == "!!str")) |= envsubst' /
   done
 fi
 
-if [[ "$(yq --output-format=json e '(.. | select(tag == "!!str")) |= envsubst' /data/config.yml 2>/dev/null | jq '.global')" != "null" ]]; then
-  for global in $(yq --output-format=json e '(.. | select(tag == "!!str")) |= envsubst' /data/config.yml 2>/dev/null | jq -r '.global[] | @base64'); do
+if [[ "$(yq --output-format=json e '(.. | select(tag == "!!str")) |= envsubst' $CONFIG_FILE 2>/dev/null | jq '.global')" != "null" ]]; then
+  for global in $(yq --output-format=json e '(.. | select(tag == "!!str")) |= envsubst' $CONFIG_FILE 2>/dev/null | jq -r '.global[] | @base64'); do
   echo "Add global option: $(echo "$global" | base64 --decode)"
   cat >> /etc/samba/smb.conf <<EOL
 $(echo "$global" | base64 --decode)
@@ -133,8 +133,8 @@ EOL
   done
 fi
 
-if [[ "$(yq --output-format=json e '(.. | select(tag == "!!str")) |= envsubst' /data/config.yml 2>/dev/null | jq '.share')" != "null" ]]; then
-  for share in $(yq --output-format=json e '(.. | select(tag == "!!str")) |= envsubst' /data/config.yml 2>/dev/null | jq -r '.share[] | @base64'); do
+if [[ "$(yq --output-format=json e '(.. | select(tag == "!!str")) |= envsubst' $CONFIG_FILE 2>/dev/null | jq '.share')" != "null" ]]; then
+  for share in $(yq --output-format=json e '(.. | select(tag == "!!str")) |= envsubst' $CONFIG_FILE 2>/dev/null | jq -r '.share[] | @base64'); do
     _jq() {
       echo "${share}" | base64 --decode | jq -r "${1}"
     }


### PR DESCRIPTION
This is useful to separate the config file from the internal cache created by samba.

```
  samba:
    image: docker-samba
    container_name: samba
    network_mode: host
    volumes:
      - ./samba.yml:/config/config.yml
      - samba-cache:/data
      - "/home/ubuntu/Share:/samba/Share"
    environment:
      - "CONFIG_FILE=/config/config.yml"
    restart: unless-stopped

volumes:
  samba-cache:
```