### PR TITLE
Set the previously unset idmap range

### DIFF
--- a/rootfs/etc/cont-init.d/01-config.sh
+++ b/rootfs/etc/cont-init.d/01-config.sh
@@ -49,6 +49,7 @@ server role = standalone server
 server services = -dns, -nbt
 server signing = default
 server multi channel support = yes
+idmap config * : range = 5000-7999
 
 log level = ${SAMBA_LOG_LEVEL}
 ;log file = /usr/local/samba/var/log.%m


### PR DESCRIPTION
Docker-samba by crazy-max keeps shouting:
`idmap range not specified for domain '*'`
when log level is above 0.

So i tracked it down to an idmap variable for some userid ranges not being set.
And in this pull request i set it to 5000-7999 (this is arbitrary) which i think supports exactly 2999 users.

I also read online that these IDs should not overlap over any user accounts that exist on the system, but i don't know if having this in docker changes that.

So in conclusion:
- This pull request fixes that bug where it spams an error every 5-10 seconds
- We still need an expert looking at this to make sure i didn't create a ticking timebomb

GL guys!