### PR TITLE
Add additional share config options

### DIFF
--- a/examples/compose/data/config.yml
+++ b/examples/compose/data/config.yml
@@ -39,6 +39,8 @@ share:
     writelist: foo
     veto: no
     hidefiles: /_*/
+    createmask: 644
+    directorymask: 755
   - name: foo-baz
     path: /samba/foo-baz
     browsable: yes
@@ -47,3 +49,5 @@ share:
     validusers: foo,baz
     writelist: foo,baz
     veto: no
+    forcecreatemode: 644
+    forcedirectorymode: 755

--- a/rootfs/etc/cont-init.d/01-config.sh
+++ b/rootfs/etc/cont-init.d/01-config.sh
@@ -191,6 +191,18 @@ if [[ "$(yq --output-format=json e '(.. | select(tag == "!!str")) |= envsubst' "
       echo "recycle:keeptree = yes" >> /etc/samba/smb.conf
       echo "recycle:versions = yes" >> /etc/samba/smb.conf
     fi
+    if [[ "$(_jq '.createmask')" != "null" ]] && [[ -n "$(_jq '.createmask')" ]]; then
+      echo "create mask = $(_jq '.createmask')" >> /etc/samba/smb.conf
+    fi
+    if [[ "$(_jq '.directorymask')" != "null" ]] && [[ -n "$(_jq '.directorymask')" ]]; then
+      echo "directory mask = $(_jq '.directorymask')" >> /etc/samba/smb.conf
+    fi
+    if [[ "$(_jq '.forcecreatemode')" != "null" ]] && [[ -n "$(_jq '.forcecreatemode')" ]]; then
+      echo "force create mode = $(_jq '.forcecreatemode')" >> /etc/samba/smb.conf
+    fi
+    if [[ "$(_jq '.forcedirectorymode')" != "null" ]] && [[ -n "$(_jq '.forcedirectorymode')" ]]; then
+      echo "force directory mode = $(_jq '.forcedirectorymode')" >> /etc/samba/smb.conf
+    fi
   done
 fi
 

--- a/test/data/config.yml
+++ b/test/data/config.yml
@@ -26,6 +26,8 @@ share:
     writelist: ""
     veto: no
     recycle: yes
+    forcecreatemode: 644
+    forcedirectorymode: 755
   - name: share
     path: /samba/share
     browsable: ${BROWSABLE}
@@ -33,6 +35,8 @@ share:
     guestok: yes
     writelist: foo
     veto: no
+    createmask: 644
+    directorymask: 755
   - name: foo
     path: /samba/foo
     browsable: ${BROWSABLE}


### PR DESCRIPTION
This is an updated pull-request based off https://github.com/crazy-max/docker-samba/pull/20 that attempts to address the review feedback in that PR that wasn't addressed by the original submitter.

It adds support for `createmask`, `directorymask`, `forcecreatemode`, and `forcedirectorymode` in share configs.