### PR TITLE
Only create samba user if not already existing

### DIFF
--- a/rootfs/etc/cont-init.d/01-config.sh
+++ b/rootfs/etc/cont-init.d/01-config.sh
@@ -121,7 +121,7 @@ if [[ "$(yq --output-format=json e '(.. | select(tag == "!!str")) |= envsubst' "
     echo "Creating user $(_jq '.user')/$(_jq '.group') ($(_jq '.uid'):$(_jq '.gid'))"
     id -g "$(_jq '.gid')" &>/dev/null || id -gn "$(_jq '.group')" &>/dev/null || addgroup -g "$(_jq '.gid')" -S "$(_jq '.group')"
     id -u "$(_jq '.uid')" &>/dev/null || id -un "$(_jq '.user')" &>/dev/null || adduser -u "$(_jq '.uid')" -G "$(_jq '.group')" "$(_jq '.user')" -SHD
-    echo -e "$password\n$password" | smbpasswd -a -s "$(_jq '.user')"
+    pdbedit -L -u "$(_jq '.user')" &>/dev/null || echo -e "$password\n$password" | smbpasswd -a -s "$(_jq '.user')"
     unset password
   done
 fi


### PR DESCRIPTION
I would like to manage my user's passwords manually rather than put them in any configuration file in clear text. I can change the password via smbpasswd after container start. However, the password is reset/removed on every container restart, because smbpasswd is executed unconditionally if a config file is configured.

This PR introduces a check via pdbedit whether the samba user already exists and only calls smbpasswd if it does not.

As this changes the current behavior (and some people might want to keep closed-loop management of passwords via configuration), I could also add a configuration, either globally via env var or per user. Please let me know @crazy-max if you would consider this for merge but want it configurable.