### PR TITLE
fix: recycle option overrides vfs objects defined in the global section

### DIFF
--- a/rootfs/etc/cont-init.d/01-config.sh
+++ b/rootfs/etc/cont-init.d/01-config.sh
@@ -185,7 +185,7 @@ if [[ "$(yq --output-format=json e '(.. | select(tag == "!!str")) |= envsubst' "
     if [[ "$(_jq '.hidefiles')" != "null" ]] && [[ -n "$(_jq '.hidefiles')" ]]; then
       echo "hide files = $(_jq '.hidefiles')" >> /etc/samba/smb.conf
     fi
-    if [[ "$(_jq '.recycle')" != "null" ]] && [[ -n "$(_jq '.recycle')" ]]; then
+    if [[ "$(_jq '.recycle')" != "null" ]] && [[ "$(_jq '.recycle')" = "yes" ]]; then
       echo "vfs objects = recycle" >> /etc/samba/smb.conf
       echo "recycle:repository = .recycle" >> /etc/samba/smb.conf
       echo "recycle:keeptree = yes" >> /etc/samba/smb.conf


### PR DESCRIPTION
Previously `recycle` field value wasn't checked and it was always set with this small change it checks if it's set to `yes` and if so it appends its configuration to `/etc/samba/smb.conf`. 

This is crucial to make Samba works in write-mode with iOS. `"vfs objects = recycle"` overrides the global configuration `vfs objects = fruit streams_xattr`

fixes: #132