### PR TITLE
Avahi Zeroconf discovery support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,6 +26,7 @@ FROM crazymax/alpine-s6:${ALPINE_VERSION}-${S6_VERSION}
 ARG SAMBA_VERSION
 ARG SAMBA_REVISION
 RUN apk --update --no-cache add \
+    avahi \
     bash \
     coreutils \
     jq \
@@ -33,12 +34,14 @@ RUN apk --update --no-cache add \
     shadow \
     tzdata \
     yq \
+  && sed -i 's/^#*enable-dbus=.*/enable-dbus=no/' /etc/avahi/avahi-daemon.conf \
+  && rm -f /etc/avahi/services/* \
   && rm -rf /tmp/*
 
 COPY --from=wsdd2 /dist/usr/sbin/wsdd2 /usr/bin/
 COPY rootfs /
 
-EXPOSE 445 3702/tcp 3702/udp 5355/tcp 5355/udp
+EXPOSE 445 5353/udp 3702/tcp 3702/udp 5355/tcp 5355/udp
 VOLUME [ "/data" ]
 ENTRYPOINT [ "/init" ]
 

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ ___
 * [Notes](#notes)
   * [Variable interpolation](#variable-interpolation)
   * [Status](#status)
+  * [Service discovery for Linux and macOS](#service-discovery-for-linux-and-macos)
   * [Service discovery for Windows](#service-discovery-for-windows)
 * [Upgrade](#upgrade)
 * [Contributing](#contributing)
@@ -46,6 +47,7 @@ ___
 * Easy [configuration](#configuration) through YAML
 * Improve [operability with Mac OS X clients](https://wiki.samba.org/index.php/Configure_Samba_to_Work_Better_with_Mac_OS_X)
 * Drop support for legacy protocols including NetBIOS, WINS, and Samba port 139
+* [Service discovery for Linux and macOS](#service-discovery-for-linux-and-macos) supported using [Avahi](https://www.avahi.org/)
 * [Service discovery for Windows](#service-discovery-for-windows) supported using [WSDD2](https://github.com/Netgear/wsdd2)
 
 ## Build locally
@@ -95,6 +97,10 @@ linux/s390x
 * `SAMBA_WIDE_LINKS`: Controls whether or not links in the UNIX file system may be followed by the server. (default `yes`)
 * `SAMBA_HOSTS_ALLOW`: Set of hosts which are permitted to access a service. (default `127.0.0.0/8 10.0.0.0/8 172.16.0.0/12 192.168.0.0/16`)
 * `SAMBA_INTERFACES`: Allows you to override the default network interfaces list.
+* `AVAHI_ENABLE`: Enable [service discovery for Linux and macOS](#service-discovery-for-linux-and-macos) (default `0`)
+* `AVAHI_INTERFACES`: Comma-separated network interfaces Avahi is allowed to use
+* `AVAHI_MODEL`: Finder device model advertised through Avahi (default `RackMac`)
+* `AVAHI_ADISK_NAME`: Time Machine share name advertised through `_adisk._tcp` (disabled by default)
 * `WSDD2_ENABLE`: Enable [service discovery for Windows](#service-discovery-for-windows) (default `0`)
 * `WSDD2_HOSTNAME`: Override hostname (default to host or container name)
 * `WSDD2_NETBIOS_NAME`: Set NetBIOS name (default to hostname)
@@ -110,6 +116,7 @@ linux/s390x
 ## Ports
 
 * `445`: SMB over TCP port
+* `5353`: mDNS UDP port
 * `3702`: WS-Discovery TCP/UDP port
 * `5355`: LLMNR TCP/UDP port
 
@@ -276,6 +283,30 @@ Use the following commands to check the logs and status:
 docker compose logs samba
 docker compose exec samba smbstatus
 ```
+
+### Service discovery for Linux and macOS
+
+Zeroconf service discovery for Linux and macOS clients can be enabled by
+setting `AVAHI_ENABLE` to `1`. It publishes the `_smb._tcp` service on port
+`445` and a `_device-info._tcp` record for Finder using [Avahi](https://www.avahi.org/).
+
+If you use Samba as a Time Machine target, set `AVAHI_ADISK_NAME` to the
+matching share name to publish an `_adisk._tcp` record. No `_adisk._tcp` record
+is published by default because advertising a non-existent Time Machine share
+breaks client expectations.
+
+mDNS uses multicast UDP port `5353`, so the container must use host networking
+on a Linux host. Docker Desktop host networking on macOS and Windows does not
+provide LAN-visible multicast discovery for this use case.
+
+The advertised name follows the container hostname. Set `hostname` in your
+compose file to control the `.local` name.
+
+Avahi listens on every interface by default. Set `AVAHI_INTERFACES`, for
+example `eth0`, to avoid advertising on Docker bridge, loopback, or veth
+interfaces.
+
+See [examples/zeroconf](examples/zeroconf) as an example.
 
 ### Service discovery for Windows
 

--- a/examples/zeroconf/compose.yml
+++ b/examples/zeroconf/compose.yml
@@ -1,0 +1,23 @@
+name: samba
+
+services:
+  samba:
+    image: crazymax/samba
+    container_name: samba
+    hostname: docker-samba
+    network_mode: host
+    volumes:
+      - "./data:/data"
+      - "./public:/samba/public"
+      - "./share:/samba/share"
+      - "./foo:/samba/foo"
+      - "./foo-baz:/samba/foo-baz"
+    environment:
+      - "TZ=Europe/Paris"
+      - "SAMBA_LOG_LEVEL=0"
+      - "AVAHI_ENABLE=1"
+      # Restrict Avahi to the LAN-facing interface if needed.
+      #- "AVAHI_INTERFACES=eth0"
+      # Set to a real Time Machine share name to publish _adisk._tcp.
+      #- "AVAHI_ADISK_NAME=TimeMachine"
+    restart: always

--- a/examples/zeroconf/data/config.yml
+++ b/examples/zeroconf/data/config.yml
@@ -1,0 +1,49 @@
+auth:
+  - user: foo
+    group: foo
+    uid: 1000
+    gid: 1000
+    password: bar
+  - user: baz
+    group: xxx
+    uid: 1100
+    gid: 1200
+    password_file: /run/secrets/baz_password
+
+global:
+  - "force user = foo"
+  - "force group = foo"
+
+share:
+  - name: public
+    comment: Public
+    path: /samba/public
+    browsable: yes
+    readonly: yes
+    guestok: yes
+    veto: no
+    recycle: yes
+  - name: share
+    path: /samba/share
+    browsable: yes
+    readonly: no
+    guestok: yes
+    writelist: foo
+    veto: no
+  - name: foo
+    path: /samba/foo
+    browsable: yes
+    readonly: no
+    guestok: no
+    validusers: foo
+    writelist: foo
+    veto: no
+    hidefiles: /_*/
+  - name: foo-baz
+    path: /samba/foo-baz
+    browsable: yes
+    readonly: no
+    guestok: no
+    validusers: foo,baz
+    writelist: foo,baz
+    veto: no

--- a/rootfs/etc/cont-init.d/04-svc-avahi.sh
+++ b/rootfs/etc/cont-init.d/04-svc-avahi.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/with-contenv sh
+# shellcheck shell=sh
+
+: "${AVAHI_ENABLE=0}"
+: "${AVAHI_INTERFACES=}"
+: "${AVAHI_MODEL=RackMac}"
+: "${AVAHI_ADISK_NAME=}"
+
+if [ "$AVAHI_ENABLE" != "1" ]; then
+  exit 0
+fi
+
+xml_escape() {
+  printf '%s' "$1" | sed -e 's/&/\&amp;/g' -e 's/</\&lt;/g' -e 's/>/\&gt;/g'
+}
+
+sed_escape() {
+  printf '%s' "$1" | sed -e 's/[\/&]/\\&/g'
+}
+
+avahiModel=$(xml_escape "${AVAHI_MODEL}")
+avahiAdiskName=$(xml_escape "${AVAHI_ADISK_NAME}")
+avahiInterfaces=$(sed_escape "${AVAHI_INTERFACES}")
+
+if [ -n "${AVAHI_INTERFACES}" ]; then
+  sed -i "s/^#*allow-interfaces=.*/allow-interfaces=${avahiInterfaces}/" /etc/avahi/avahi-daemon.conf
+fi
+
+mkdir -p /etc/avahi/services
+cat > /etc/avahi/services/samba.service <<EOL
+<?xml version="1.0" standalone="no"?>
+<!DOCTYPE service-group SYSTEM "avahi-service.dtd">
+<service-group>
+  <name replace-wildcards="yes">%h</name>
+  <service>
+    <type>_smb._tcp</type>
+    <port>445</port>
+  </service>
+  <service>
+    <type>_device-info._tcp</type>
+    <port>0</port>
+    <txt-record>model=${avahiModel}</txt-record>
+  </service>
+EOL
+
+if [ -n "${AVAHI_ADISK_NAME}" ]; then
+  cat >> /etc/avahi/services/samba.service <<EOL
+  <service>
+    <type>_adisk._tcp</type>
+    <port>9</port>
+    <txt-record>sys=waMa=0,adVF=0x100</txt-record>
+    <txt-record>dk0=adVN=${avahiAdiskName},adVF=0x82</txt-record>
+  </service>
+EOL
+fi
+
+cat >> /etc/avahi/services/samba.service <<EOL
+</service-group>
+EOL
+
+mkdir -p /etc/services.d/avahi
+
+cat > /etc/services.d/avahi/run <<EOL
+#!/usr/bin/execlineb -P
+with-contenv
+exec /usr/sbin/avahi-daemon --no-rlimits
+EOL
+chmod +x /etc/services.d/avahi/run

--- a/test/compose.yml
+++ b/test/compose.yml
@@ -19,6 +19,7 @@ services:
     environment:
       - "TZ=Europe/Paris"
       - "BROWSABLE=yes"
+      - "AVAHI_ENABLE=1"
       - "WSDD2_ENABLE=1"
       - "WSDD2_NETBIOS_NAME=docker_samba"
     restart: always


### PR DESCRIPTION
fixes #1 

The image now installs Avahi, disables D-Bus for container use, removes Avahi's default SSH service advertisements, and creates an Avahi service at startup when `AVAHI_ENABLE=1`.