### PR TITLE
fix healthcheck with restricted anonymous access

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -44,4 +44,4 @@ VOLUME [ "/data" ]
 ENTRYPOINT [ "/init" ]
 
 HEALTHCHECK --interval=30s --timeout=10s \
-  CMD smbclient -L \\localhost -U % -m SMB3
+  CMD ["sh", "/usr/local/bin/healthcheck"]

--- a/rootfs/usr/local/bin/healthcheck
+++ b/rootfs/usr/local/bin/healthcheck
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+out="$(smbclient -L \\localhost -U % -m SMB3 2>&1)"
+rc=$?
+
+if printf '%s\n' "$out" | grep -q 'NT_STATUS_ACCESS_DENIED'; then
+  exit 0
+fi
+
+exit "$rc"


### PR DESCRIPTION
fixes #101
fixes #141

Treat `NT_STATUS_ACCESS_DENIED` as a healthy response so containers remain healthy when anonymous share listing is intentionally disabled.

Preserve the smbclient exit status for all other failures so timeouts and connection errors still fail the healthcheck.
