### PR TITLE
avahi name overrides support

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,8 @@ linux/s390x
 * `SAMBA_INTERFACES`: Allows you to override the default network interfaces list.
 * `AVAHI_ENABLE`: Enable [service discovery for Linux and macOS](#service-discovery-for-linux-and-macos) (default `0`)
 * `AVAHI_INTERFACES`: Comma-separated network interfaces Avahi is allowed to use
+* `AVAHI_NAME`: Service instance name advertised through Avahi (default `%h` for the Avahi hostname)
+* `AVAHI_HOSTNAME`: Avahi hostname without the `.local` suffix (default to the container hostname)
 * `AVAHI_MODEL`: Finder device model advertised through Avahi (default `RackMac`)
 * `AVAHI_ADISK_NAME`: Time Machine share name advertised through `_adisk._tcp` (disabled by default)
 * `WSDD2_ENABLE`: Enable [service discovery for Windows](#service-discovery-for-windows) (default `0`)
@@ -302,8 +304,15 @@ mDNS uses multicast UDP port `5353`, so the container must use host networking
 on a Linux host. Docker Desktop host networking on macOS and Windows does not
 provide LAN-visible multicast discovery for this use case.
 
-The advertised name follows the container hostname. Set `hostname` in your
-compose file to control the `.local` name.
+The advertised service name follows the Avahi hostname by default. Set
+`AVAHI_NAME` to control the name shown by service browsers such as Finder
+without changing the host address record.
+
+Set `AVAHI_HOSTNAME` to control the `.local` host name used by Avahi. Do not
+include the `.local` suffix. This changes the host address record, so prefer
+`AVAHI_NAME` when you only need a friendlier service name. If another mDNS stack
+is already running on the host network, competing host address records can cause
+Avahi host name conflicts.
 
 Avahi listens on every interface by default. Set `AVAHI_INTERFACES`, for
 example `eth0`, to avoid advertising on Docker bridge, loopback, or veth

--- a/examples/zeroconf/compose.yml
+++ b/examples/zeroconf/compose.yml
@@ -4,7 +4,6 @@ services:
   samba:
     image: crazymax/samba
     container_name: samba
-    hostname: docker-samba
     network_mode: host
     volumes:
       - "./data:/data"
@@ -16,6 +15,8 @@ services:
       - "TZ=Europe/Paris"
       - "SAMBA_LOG_LEVEL=0"
       - "AVAHI_ENABLE=1"
+      - "AVAHI_NAME=Docker Samba"
+      #- "AVAHI_HOSTNAME=docker-samba"
       # Restrict Avahi to the LAN-facing interface if needed.
       #- "AVAHI_INTERFACES=eth0"
       # Set to a real Time Machine share name to publish _adisk._tcp.

--- a/rootfs/etc/cont-init.d/04-svc-avahi.sh
+++ b/rootfs/etc/cont-init.d/04-svc-avahi.sh
@@ -3,6 +3,8 @@
 
 : "${AVAHI_ENABLE=0}"
 : "${AVAHI_INTERFACES=}"
+: "${AVAHI_NAME=%h}"
+: "${AVAHI_HOSTNAME=}"
 : "${AVAHI_MODEL=RackMac}"
 : "${AVAHI_ADISK_NAME=}"
 
@@ -20,7 +22,13 @@ sed_escape() {
 
 avahiModel=$(xml_escape "${AVAHI_MODEL}")
 avahiAdiskName=$(xml_escape "${AVAHI_ADISK_NAME}")
+avahiName=$(xml_escape "${AVAHI_NAME}")
 avahiInterfaces=$(sed_escape "${AVAHI_INTERFACES}")
+avahiHostname=$(sed_escape "${AVAHI_HOSTNAME}")
+
+if [ -n "${AVAHI_HOSTNAME}" ]; then
+  sed -i "s/^#*host-name=.*/host-name=${avahiHostname}/" /etc/avahi/avahi-daemon.conf
+fi
 
 if [ -n "${AVAHI_INTERFACES}" ]; then
   sed -i "s/^#*allow-interfaces=.*/allow-interfaces=${avahiInterfaces}/" /etc/avahi/avahi-daemon.conf
@@ -31,7 +39,7 @@ cat > /etc/avahi/services/samba.service <<EOL
 <?xml version="1.0" standalone="no"?>
 <!DOCTYPE service-group SYSTEM "avahi-service.dtd">
 <service-group>
-  <name replace-wildcards="yes">%h</name>
+  <name replace-wildcards="yes">${avahiName}</name>
   <service>
     <type>_smb._tcp</type>
     <port>445</port>


### PR DESCRIPTION
fixes https://github.com/crazy-max/docker-samba/issues/181

Allow `AVAHI_NAME` to customize the advertised service name without changing the Avahi host address record.

Allow `AVAHI_HOSTNAME` to override the Avahi daemon host name when users intentionally need a different .local record.

Also some docs for safer service-name path for host-network deployments where another mDNS stack can already own the host address record.
