### PR TITLE
add per-share samba options

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ ___
   * [`veto`](#veto)
   * [`hidefiles`](#hidefiles)
   * [`recycle`](#recycle)
+  * [`options`](#options)
 * [Usage](#usage)
   * [Docker Compose](#docker-compose)
   * [Command line](#command-line)
@@ -158,6 +159,10 @@ share:
     veto: no
     hidefiles: /_*/
     recycle: yes
+    options:
+      - "create mask = 0644"
+      - "directory mask = 0755"
+      - "store dos attributes = yes"
 ```
 
 A more complete `config.yml` example is available [here](examples/compose/data/config.yml).
@@ -200,6 +205,32 @@ shares keep a consistent VFS configuration.
 
 > [!NOTE]
 > https://www.samba.org/samba/docs/current/man-html/vfs_recycle.8.html
+
+### `options`
+
+`options` is a list of raw Samba share parameters appended to the generated
+share section. Use it for share-specific settings that are not modeled as
+first-class YAML keys:
+
+```yaml
+share:
+  - name: media
+    path: /samba/media
+    readonly: no
+    guestok: yes
+    options:
+      - "create mask = 0664"
+      - "directory mask = 0775"
+      - "force user = media"
+      - "force group = media"
+      - "store dos attributes = yes"
+```
+
+These options are written after the generated share settings, so they can also
+override generated defaults when needed.
+
+> [!NOTE]
+> https://www.samba.org/samba/docs/current/man-html/smb.conf.5.html
 
 ## Usage
 

--- a/examples/compose/data/config.yml
+++ b/examples/compose/data/config.yml
@@ -30,6 +30,12 @@ share:
     guestok: yes
     writelist: foo
     veto: no
+    options:
+      - "create mask = 0644"
+      - "directory mask = 0755"
+      - "force user = foo"
+      - "force group = foo"
+      - "store dos attributes = yes"
   - name: foo
     path: /samba/foo
     browsable: yes

--- a/rootfs/etc/cont-init.d/01-config.sh
+++ b/rootfs/etc/cont-init.d/01-config.sh
@@ -191,6 +191,13 @@ if [[ "$(yq --output-format=json e '(.. | select(tag == "!!str")) |= envsubst' "
       echo "recycle:keeptree = yes" >> /etc/samba/smb.conf
       echo "recycle:versions = yes" >> /etc/samba/smb.conf
     fi
+    if [[ "$(_jq '.options')" != "null" ]]; then
+      for option in $(echo "${share}" | base64 --decode | jq -r '.options[] | @base64'); do
+        option=$(echo "$option" | base64 --decode)
+        echo "Add option for share $(_jq '.name'): ${option}"
+        echo "${option}" >> /etc/samba/smb.conf
+      done
+    fi
   done
 fi
 

--- a/test/data/config.yml
+++ b/test/data/config.yml
@@ -31,8 +31,13 @@ share:
     browsable: ${BROWSABLE}
     readonly: no
     guestok: yes
-    writelist: foo
     veto: no
+    options:
+      - "create mask = 0644"
+      - "directory mask = 0755"
+      - "force user = yyy"
+      - "force group = xxx"
+      - "store dos attributes = yes"
   - name: foo
     path: /samba/foo
     browsable: ${BROWSABLE}


### PR DESCRIPTION
fixes #100
fixes #120 

This adds an options list to each generated share so users can append arbitrary Samba share parameters without adding one YAML key per Samba knob.