### PR TITLE
set default Samba idmap range

### DIFF
--- a/rootfs/etc/s6-overlay/scripts/config
+++ b/rootfs/etc/s6-overlay/scripts/config
@@ -64,6 +64,8 @@ server role = standalone server
 server services = -dns, -nbt
 server signing = default
 server multi channel support = yes
+idmap config * : backend = tdb
+idmap config * : range = 1000000-1999999
 
 log level = ${SAMBA_LOG_LEVEL}
 ;log file = /usr/local/samba/var/log.%m


### PR DESCRIPTION
closes #106

Configure the fallback tdb idmap backend with a high UID and GID allocation range so Samba no longer emits the missing idmap range warning at nonzero log levels.